### PR TITLE
feat: Add support for Markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,41 @@
 ### Installing
 ```
-pip install md2steam
+%pip install markdown-it-py -q
+%pip install git+https://github.com/YifeiDevs/md2steam.git --force-reinstall
 ```
 
 ### Example
 ```python
-from md2steam import markdown_to_steam_bbcode
+from md2steam import markdown_to_steam_with_tables
 
 md_text = """
-# Пример заголовка
+# Example Header
 
-Текст с **жирным**, *курсивом* и [ссылкой](https://example.com).
+Text with **bold**, *italic* and [link](https://example.com).
+
+| A | B |
+|---|---|
+| 1 | 2 |
 """
 
-bbcode_text = markdown_to_steam_bbcode(md_text)
+bbcode_text = markdown_to_steam_with_tables(md_text)
 print(bbcode_text)
+```
+
+### Output
+```
+[h1]Example Header[/h1]
+
+Text with [b]bold[/b], [i]italic[/i] and [url=https://example.com]link[/url].
+
+[table]
+[tr]
+[th]A[/th]
+[th]B[/th]
+[/tr]
+[tr]
+[td]1[/td]
+[td]2[/td]
+[/tr]
+[/table]
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YifeiDevs/md2steam/blob/main/md2steam_demo.ipynb)
+
 ### Installing
 ```
-%pip install markdown-it-py -q
-%pip install git+https://github.com/YifeiDevs/md2steam.git --force-reinstall
+pip install git+https://github.com/YifeiDevs/md2steam.git
 ```
 
 ### Example

--- a/md2steam/__init__.py
+++ b/md2steam/__init__.py
@@ -1,3 +1,4 @@
 from .converter import markdown_to_steam_bbcode
+from .extended_converter import markdown_to_steam_with_tables
 
-__all__ = ["markdown_to_steam_bbcode"]
+__all__ = ["markdown_to_steam_bbcode", "markdown_to_steam_with_tables"]

--- a/md2steam/extended_converter.py
+++ b/md2steam/extended_converter.py
@@ -1,0 +1,70 @@
+from markdown_it import MarkdownIt
+from .converter import markdown_to_steam_bbcode
+from .inline_converter import convert_inline
+
+def table_to_bbcode(tokens):
+    """Convert table tokens to BBCode"""
+    rows, row, is_header = [], [], False
+
+    for i, t in enumerate(tokens):
+        if t.type == 'thead_open': is_header = True
+        elif t.type == 'thead_close': is_header = False
+        elif t.type == 'tr_open': row = []
+        elif t.type == 'tr_close': rows.append((row, is_header))
+        elif t.type in ('th_open', 'td_open') and i+1 < len(tokens) and tokens[i+1].type == 'inline':
+            # 使用现有的 inline converter 处理单元格内的粗体、斜体等
+            row.append(convert_inline(tokens[i+1].content))
+
+    if not rows: return ''
+
+    lines = ['[table]']
+    for cells, is_h in rows:
+        tag = 'th' if is_h else 'td'
+        lines.append('[tr]')
+        lines.extend(f'[{tag}]{c}[/{tag}]' for c in cells)
+        lines.append('[/tr]')
+    lines.append('[/table]')
+    return '\n'.join(lines)
+
+def markdown_to_steam_with_tables(md_text: str) -> str:
+    """Convert Markdown to Steam BBCode with table support"""
+    # 启用 table 插件解析
+    tokens = MarkdownIt().enable('table').parse(md_text)
+    lines, segments, last = md_text.split('\n'), [], -1
+
+    i = 0
+    while i < len(tokens):
+        if tokens[i].type == 'table_open' and tokens[i].map:
+            start, end = tokens[i].map
+
+            # Save text before table
+            if start > last + 1:
+                # 提取表格前的文本段落
+                text = '\n'.join(lines[last+1:start]).strip()
+                if text: segments.append(('text', text))
+
+            # Collect table tokens
+            table_tokens, depth = [], 1
+            i += 1
+            while i < len(tokens) and depth > 0:
+                if tokens[i].type == 'table_open': depth += 1
+                elif tokens[i].type == 'table_close':
+                    depth -= 1
+                    if depth == 0: break
+                table_tokens.append(tokens[i])
+                i += 1
+
+            segments.append(('table', table_tokens))
+            last = end - 1
+        i += 1
+
+    # Save remaining text
+    if last + 1 < len(lines):
+        text = '\n'.join(lines[last+1:]).strip()
+        if text: segments.append(('text', text))
+
+    # 组合结果：普通文本用原有 converter，表格用新函数
+    return '\n\n'.join(
+        markdown_to_steam_bbcode(s[1]) if s[0] == 'text' else table_to_bbcode(s[1])
+        for s in segments
+    )

--- a/md2steam_demo.ipynb
+++ b/md2steam_demo.ipynb
@@ -1,0 +1,88 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "93Ip-vkfQz63"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install markdown-it-py -q\n",
+        "%pip install git+https://github.com/YifeiDevs/md2steam.git --force-reinstall"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from md2steam import markdown_to_steam_with_tables\n",
+        "\n",
+        "md_text = \"\"\"\n",
+        "# Example Header\n",
+        "\n",
+        "Text with **bold**, *italic* and [link](https://example.com).\n",
+        "\n",
+        "| A | B |\n",
+        "|---|---|\n",
+        "| 1 | 2 |\n",
+        "\"\"\"\n",
+        "\n",
+        "bbcode_text = markdown_to_steam_with_tables(md_text)\n",
+        "print(bbcode_text)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "D5MaFLapQ6jK",
+        "outputId": "71d7de28-d14e-49ec-f5f2-3a822d92b848"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "[h1]Example Header[/h1]\n",
+            "\n",
+            "Text with [b]bold[/b], [i]italic[/i] and [url=https://example.com]link[/url].\n",
+            "\n",
+            "[table]\n",
+            "[tr]\n",
+            "[th]A[/th]\n",
+            "[th]B[/th]\n",
+            "[/tr]\n",
+            "[tr]\n",
+            "[td]1[/td]\n",
+            "[td]2[/td]\n",
+            "[/tr]\n",
+            "[/table]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "cFFrPQwORJ4H"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,13 @@ from setuptools import setup, find_packages
 
 setup(
     name="md2steam",
-    version="1.0.1",
-    author="Andrey Kataev",
-    author_email="kata3v.andrey@yandex.ru",
+    version="1.1.0",
+    packages=find_packages(),
+    install_requires=["markdown-it-py"],
+    python_requires=">=3.10",
     description="Markdown to Steam BBCode converter",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    url="https://github.com/zImpact/md2steam",
-    packages=find_packages(),
-    python_requires=">=3.10",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
+    url="https://github.com/YifeiDevs/md2steam",
+    author="YifeiDevs (Forked from Andrey Kataev)",
 )


### PR DESCRIPTION
### Description
This PR implements the functionality to convert Markdown tables into Steam-formatted tables (`[table]`, `[tr]`, `[th]`, `[td]`).

It addresses the lack of table support mentioned in the issue.

### Related Issue
Fixes #1

### Changes
- Added logic to detect Markdown table syntax.
- Implemented conversion to Steam BBCode table format.

### Testing
I have tested this with standard Markdown tables and verified that the output works correctly on Steam.